### PR TITLE
Add NPM script for starting Gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ cd design-blocks
 
 ```bash
 npm install
-gulp
+npm run gulp
 ```
 
 ## Contributors

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
       "name": "Froala Labs"
     }
   ],
+  "scripts": {
+    "gulp": "gulp"
+  },
   "devDependencies": {
     "del": "^3.0.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
Typing `gulp` in the terminal will not start the gulp server unless it's installed globally. The NPM script enables a local install of gulp to be run by running `npm run gulp`.