### PR TITLE
Automate screenshot taking process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var copy = require('gulp-copy');
 var connect = require('gulp-connect');
 var del = require('del');
 var vinylPaths = require('vinyl-paths');
+var utils = require('./utils');
 
 gulp.task('clean', function () {
   del.sync('dist/**/*');
@@ -45,6 +46,25 @@ gulp.task('connect', function () {
         port: 8001,
         livereload: true
     });
+});
+
+gulp.task('screenshots', function(cb) {
+  del.sync('./screenshots');
+
+  utils.makeScreenshots([
+    ['call_to_action', 'header, section, footer'],
+    ['contacts', 'header, section, footer'],
+    ['contents', 'header, section, footer'],
+    ['features', 'header, section, footer'],
+    ['footers', 'header, section, footer'],
+    ['forms', 'header, section, footer'],
+    ['headers', 'header, section, footer'],
+    ['pricings', 'header, section, footer'],
+    ['teams', 'header, section, footer'],
+    ['testimonials', 'header, section, footer'],
+  ]).then(function() {
+    cb();
+  });
 });
 
 gulp.task('build', ['clean', 'html', 'imgs', 'sass']);

--- a/package.json
+++ b/package.json
@@ -29,14 +29,17 @@
   },
   "devDependencies": {
     "del": "^3.0.0",
+    "fs-extra": "^4.0.2",
     "gulp": "^3.9.1",
     "gulp-connect": "^5.0.0",
     "gulp-copy": "^1.0.0",
     "gulp-livereload": "^3.8.1",
     "gulp-open": "^2.0.0",
     "gulp-sass": "^3.1.0",
+    "gulp-util": "^3.0.8",
     "gulp-watch": "^4.3.11",
-    "node-sass": "^4.5.3"
+    "node-sass": "^4.5.3",
+    "puppeteer": "^0.12.0"
   },
   "dependencies": {
     "bootstrap": "^4.0.0-beta",

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,0 +1,73 @@
+const fs = require('fs-extra');
+const gutil = require('gulp-util');
+const puppeteer = require('puppeteer');
+
+function delay(timeout) {
+  return new Promise(function(resolve) {
+    setTimeout(resolve, timeout);
+  })
+};
+
+function getDirPath(name) {
+  return `./screenshots/${name}`;
+};
+
+function getFileName(index) {
+  return `${index + 1}.jpg`;
+};
+
+function getUrl(name) {
+  return `http://127.0.0.1:8001/${name}.html`;
+};
+
+async function makeScreenshotsByName(name, selector) {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+
+  await page.setViewport({
+    width: 1536,
+    height: 30000, // Fix after https://github.com/GoogleChrome/puppeteer/issues/959 is closed
+    deviceScaleFactor: 2
+  });
+
+  const url = getUrl(name);
+
+  await page.goto(url, { timeout: 90000 });
+
+  const dirPath = getDirPath(name);
+
+  await fs.ensureDirSync(dirPath);
+
+  await delay(3000);
+
+  const blocks = await page.$$(selector);
+
+  for (var index = 0; index < blocks.length; index++) {
+    const path = `${dirPath}/${getFileName(index)}`;
+
+    await blocks[index].screenshot({
+      path: path,
+      type: 'jpeg',
+      quality: 100,
+    });
+
+    gutil.log(`Saved screenshot for '${gutil.colors.cyan(name)}' to '${gutil.colors.magenta(path)}'`);
+  }
+
+  await browser.close();
+};
+
+const MAX_CONCURRENT_BROWSERS_COUNT = 6;
+
+async function makeScreenshots(description) {
+  if (description.length > MAX_CONCURRENT_BROWSERS_COUNT) {
+    await makeScreenshots(description.slice(0, MAX_CONCURRENT_BROWSERS_COUNT));
+    await makeScreenshots(description.slice(MAX_CONCURRENT_BROWSERS_COUNT));
+  } else {
+    await Promise.all(description.map(([name, selector]) => makeScreenshotsByName(name, selector)));
+  }
+};
+
+module.exports = {
+  makeScreenshots,
+};


### PR DESCRIPTION
Resolve #11 

Added `gulp screenshots` command for taking screenshots via `puppeteer`

I think we can remove 3000ms delay, but I don't know other ways to wait full loading now. I researching other ways to do it, but now it works for me and it good start point to automate.