### PR TITLE
replace input-group-btn with input-group-append

### DIFF
--- a/src/html/forms/forms_01.html
+++ b/src/html/forms/forms_01.html
@@ -5,9 +5,9 @@
         <h1>Subscribe</h1>
         <div class="input-group mt-4 mb-4">
           <input type="text" class="form-control" placeholder="Enter your email address">
-          <span class="input-group-btn">
-              <button class="btn" type="button">Submit</button>
-            </span>
+          <div class="input-group-append">
+            <button class="btn" type="button">Submit</button>
+          </div>
         </div>
 
         <p class="text-h4">Find us on <a href="https://www.froala.com">Facebook</a> and <a href="https://www.froala.com">Twitter</a>.</p>

--- a/src/html/forms/forms_02.html
+++ b/src/html/forms/forms_02.html
@@ -9,9 +9,9 @@
         <div class="col-12 col-lg-5 text-center">
           <div class="input-group mt-4">
             <input type="text" class="form-control" placeholder="Enter your email address">
-            <span class="input-group-btn">
-                <button class="btn" type="button">Submit</button>
-              </span>
+            <div class="input-group-append">
+              <button class="btn" type="button">Submit</button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/html/forms/forms_09.html
+++ b/src/html/forms/forms_09.html
@@ -7,9 +7,9 @@
         <p class="text-h3">Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, there live the blind texts. </p>
         <div class="input-group mt-4 mb-4">
           <input type="text" class="form-control" placeholder="Enter your email address">
-          <span class="input-group-btn">
-              <button class="btn" type="button">Submit</button>
-            </span>
+          <div class="input-group-append">
+            <button class="btn" type="button">Submit</button>
+          </div>
         </div>
         <p class="text-h5"><em>*Your email address is safe with us. We never share your email address.</em></p>
       </div>

--- a/src/html/forms/forms_10.html
+++ b/src/html/forms/forms_10.html
@@ -6,9 +6,9 @@
         <p class="text-h3">When she reached the first hills of the Italic Mountains, she had a last view back on the skyline of her hometown.</p>
         <div class="input-group mt-5 mb-5">
           <input type="text" class="form-control" placeholder="Enter your email address">
-          <span class="input-group-btn">
-              <button class="btn" type="button">Submit</button>
-            </span>
+          <div class="input-group-append">
+            <button class="btn" type="button">Submit</button>
+          </div>
         </div>
         <p class="text-h2">
           <a href="https://www.froala.com"><i class="fab fa-facebook"></i></a>&nbsp;&nbsp;&nbsp;

--- a/src/html/forms/forms_11.html
+++ b/src/html/forms/forms_11.html
@@ -15,9 +15,9 @@
           <div class="col">
             <div class="input-group">
               <input type="text" class="form-control" placeholder="Enter your email address">
-              <span class="input-group-btn">
-                  <button class="btn" type="button">Submit</button>
-                </span>
+              <div class="input-group-append">
+                <button class="btn" type="button">Submit</button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/html/forms/forms_12.html
+++ b/src/html/forms/forms_12.html
@@ -13,9 +13,9 @@
             <div class="col-12 col-lg-10">
               <div class="input-group">
                 <input type="text" class="form-control" placeholder="Enter your email address">
-                <span class="input-group-btn">
-                    <button class="btn" type="button">Submit</button>
-                  </span>
+                <div class="input-group-append">
+                  <button class="btn" type="button">Submit</button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
* replace `.input-group-btn` with `.input-group-append`

:memo:
* https://getbootstrap.com/docs/4.1/migration/#input-groups
* https://getbootstrap.com/docs/4.1/components/input-group/

> Input group addons are now specific to their placement relative to an input. We’ve dropped `.input-group-addon` and `.input-group-btn` for two new classes, `.input-group-prepend` and `.input-group-append`.