### PR TITLE
Shouldn't we ignore /dist/ as it is built on command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/*
 .gulp-scss-cache/*
 .sass-cache/*
 .tmp/*
+dist/*
 
 # OS or Editor folders
 ._*


### PR DESCRIPTION
... and will prevent conflicts?

Just a suggestion :-)

If your host allows it, you can run the build command when pushes to your dev environment are made.